### PR TITLE
Add sbom information for submodules

### DIFF
--- a/.github/workflows/test_sbom.yml
+++ b/.github/workflows/test_sbom.yml
@@ -1,0 +1,18 @@
+name: Run SBOM submodule test
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  test_sbom:
+    name: Run SBOM submodule test
+    runs-on: ubuntu-20.04
+    container: espressif/idf:latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'true'
+      - run: |
+          git config --global safe.directory $(pwd)
+          python3 ${IDF_PATH}/tools/test_sbom/test_submodules.py

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,24 @@
+# Submodules SBOM information
+# ---------------------------
+# Submodules, which are used directly and not forked into espressif namespace should
+# contain SBOM information here. Other submodules should have the SBOM manifest file
+# included in the root of their project's repository.
+#
+# The sbom-hash entry records the submodule's checkout SHA as presented in git-tree
+# commit object. For example expat submodule:
+#
+# $ git ls-tree HEAD expat/expat
+# 160000 commit 454c6105bc2d0ea2521b8f8f7a5161c2abd8c386	expat/expat
+#
+# The hash can be also obtained with git submodule command
+#
+# $ git submodule status expat/expat/
+# 454c6105bc2d0ea2521b8f8f7a5161c2abd8c386 expat/expat (R_2_4_9-49-g454c6105)
+#
+# The submodule SHA recorded here has to match with SHA, which is presented in git-tree.
+# This is checked by CI. Also please don't forget to update the submodule version
+# if you are changing the sbom-hash. This is important for SBOM generation.
+
 [submodule "libsodium/libsodium"]
 	path = libsodium/libsodium
 	url = https://github.com/jedisct1/libsodium.git
@@ -7,12 +28,33 @@
 [submodule "nghttp/nghttp2"]
 	path = nghttp/nghttp2
 	url = https://github.com/nghttp2/nghttp2.git
+	sbom-version = 1.52.0
+	sbom-cpe = cpe:2.3:a:nghttp2:nghttp2:{}:*:*:*:*:*:*:*
+	sbom-supplier = Organization: nghttp2 <https://nghttp2.org/
+	sbom-url = https://github.com/nghttp2/nghttp2
+	sbom-description = nghttp2 - HTTP/2 C Library and tools
+	sbom-hash = be0491294a63d891bd12b6b1b7e372a45a5d0ffe
+
 [submodule "expat/expat"]
 	path = expat/expat
 	url = https://github.com/libexpat/libexpat.git
+	sbom-version = 2.5.0
+	sbom-cpe = cpe:2.3:a:libexpat_project:libexpat:{}:*:*:*:*:*:*:*
+	sbom-supplier = Organization: libexpat_project
+	sbom-url = https://github.com/libexpat/libexpat/
+	sbom-description = Fast streaming XML parser written in C99
+	sbom-hash = 454c6105bc2d0ea2521b8f8f7a5161c2abd8c386
+
 [submodule "coap/libcoap"]
 	path = coap/libcoap
 	url = https://github.com/obgm/libcoap.git
+	sbom-version = 4.3.1
+	sbom-cpe = cpe:2.3:a:libcoap:libcoap:{}:*:*:*:*:*:*:*
+	sbom-supplier = Organization: libcoap <https://libcoap.net/>
+	sbom-url = https://github.com/obgm/libcoap
+	sbom-description = A CoAP (RFC 7252) implementation in C
+	sbom-hash = c694baead2f9b408a7598e0b85c2f257ea8c9651
+
 [submodule "usb/usb_host_uvc/libuvc"]
 	path = usb/usb_host_uvc/libuvc
 	url = https://github.com/libuvc/libuvc.git
@@ -22,6 +64,13 @@
 [submodule "fmt/fmt"]
 	path = fmt/fmt
 	url = https://github.com/fmtlib/fmt.git
+	sbom-version = 9.1.0
+	sbom-cpe = cpe:2.3:a:fmt:fmt:{}:*:*:*:*:*:*:*
+	sbom-supplier = Organization: fmt <https://fmt.dev/latest/index.html>
+	sbom-url = https://github.com/fmtlib/fmt/
+	sbom-description = A modern formatting library
+	sbom-hash = a33701196adfad74917046096bf5a2aa0ab0bb50
+
 [submodule "esp_delta_ota/detools"]
 	path = esp_delta_ota/detools
 	url = https://github.com/eerimoq/detools.git
@@ -31,6 +80,19 @@
 [submodule "zlib/zlib"]
 	path = zlib/zlib
 	url = https://github.com/madler/zlib.git
+	sbom-version = 1.2.13
+	sbom-cpe = cpe:2.3:a:zlib:zlib:{}:*:*:*:*:*:*:*
+	sbom-supplier = Organization: zlib <http://www.zlib.net/>
+	sbom-url = https://github.com/madler/zlib.git
+	sbom-description = A massively spiffy yet delicately unobtrusive compression library
+	sbom-hash = 04f42ceca40f73e2978b50e93806c2a18c1281fc
+
 [submodule "libpng/libpng"]
 	path = libpng/libpng
 	url = https://github.com/glennrp/libpng.git
+	sbom-version = 1.6.39
+	sbom-cpe = cpe:2.3:a:libpng:libpng:{}:*:*:*:*:*:*:*
+	sbom-supplier = Organization: libpng
+	sbom-url = https://github.com/glennrp/libpng.git
+	sbom-description = Portable Network Graphics support, official PNG reference library
+	sbom-hash = 07b8803110da160b158ebfef872627da6c85cbdf


### PR DESCRIPTION
This adds SBOM information for submodules, which are not managed by Espressif. Meaning there is no fork for them in the espressif namespace. Other submodules should add sbom.yml manifest file to the root of their git repository.

The SBOM information for submodules is stored in the .gitmodules file. Each SBOM related variable has the "sbom-" prefix and the following variables may be used:

# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
_Please describe your change here_
